### PR TITLE
♻️ refactor: 상품 슬라이더 기능에서 데이터 3개씩 나눠서 불러오기 구현

### DIFF
--- a/src/api/productListApi.js
+++ b/src/api/productListApi.js
@@ -1,5 +1,7 @@
-export const productList = async (accountname, limit) => {
-  const reqUrl = `https://api.mandarin.weniv.co.kr/product/${accountname}/?limit=${limit}`;
+export const productList = async (accountname, limit, currentPage) => {
+  const reqUrl = `https://api.mandarin.weniv.co.kr/product/${accountname}/?limit=${limit}&skip=${
+    currentPage * 3
+  }`;
 
   try {
     const res = await fetch(reqUrl, {

--- a/src/components/campsiteFeed/CampsiteFeed.jsx
+++ b/src/components/campsiteFeed/CampsiteFeed.jsx
@@ -13,14 +13,13 @@ import {
 } from "./CampsiteFeed.style";
 import React from "react";
 
-export default function Feed({
+export default React.memo(function Feed({
   data,
   setProductId,
   setOpModal,
   reservation,
   title,
 }) {
-  //.
   return (
     <>
       <ProductContainer>
@@ -59,4 +58,4 @@ export default function Feed({
       </ProductContainer>
     </>
   );
-}
+});

--- a/src/components/userProfile/Profile.style.jsx
+++ b/src/components/userProfile/Profile.style.jsx
@@ -64,7 +64,7 @@ export const ProfileBtnWrap = styled.div`
   gap: 15px;
   color: var(--font-primary-color);
 `;
-export const ProfileBtn = styled(Link)`
+export const ProfileBtn = styled.button`
   font-size: 14px;
   background-color: ${props => (props.$follow === "true" ? `#7CB45B` : `#fff`)};
   color: ${props => (props.$follow === "true" ? "#fff" : "#767676")};

--- a/src/components/userProfile/ProfileCard.jsx
+++ b/src/components/userProfile/ProfileCard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   ProfileWrapper,
   ProfileInfoWrap,
@@ -47,6 +47,16 @@ export default React.memo(function ProfileCard({ accountUsername, data }) {
       });
     }
   };
+  function debounce(func, delay) {
+    let timer;
+    return function () {
+      clearTimeout(timer);
+      timer = setTimeout(() => func(), delay);
+    };
+  }
+  const handleFollowClick = debounce(() => {
+    handlefollowBtn();
+  }, 300);
 
   return (
     <ProfileWrapper>
@@ -86,7 +96,7 @@ export default React.memo(function ProfileCard({ accountUsername, data }) {
           <ChatShare $chat="true" />
           <ProfileBtn
             $follow={userData && userData.isfollow === true ? "false" : "true"}
-            onClick={e => handlefollowBtn(e)}
+            onClick={e => handleFollowClick(e)}
           >
             {userData && userData.isfollow ? "팔로우 취소" : "팔로우"}
           </ProfileBtn>

--- a/src/components/userProfile/ProfileProduct.jsx
+++ b/src/components/userProfile/ProfileProduct.jsx
@@ -7,7 +7,11 @@ import "swiper/css/pagination";
 import Feed from "../campsiteFeed/CampsiteFeed";
 import { ProductTitle } from "../campsiteFeed/CampsiteFeed.style";
 import emptyCampsite from "../../assets/image/empty-campsite.jpg";
-export default React.memo(function ProfileProduct({ data }) {
+export default React.memo(function ProfileProduct({
+  data,
+  setCurrentPage,
+  currentPage,
+}) {
   const [products, setProducts] = useState([]);
   useEffect(() => {
     setProducts(data);
@@ -22,6 +26,10 @@ export default React.memo(function ProfileProduct({ data }) {
         slidesPerView={1}
         pagination={{
           clickable: true,
+        }}
+        onReachEnd={() => {
+          if (data.length === (currentPage + 1) * 3)
+            setCurrentPage(pre => pre + 1);
         }}
         modules={[Pagination]}
       >

--- a/src/pages/profile/Profile.jsx
+++ b/src/pages/profile/Profile.jsx
@@ -30,36 +30,41 @@ export default function Profile() {
   const [isLoading, setIsLoading] = useState(true);
   const { accountUsername } = useParams();
   const navigate = useNavigate();
+  const [currentPage, setCurrentPage] = useState(0);
 
   useEffect(() => {
     if (accountUsername) {
       const getUserInfo = async () => {
-        const postRes = await userPost(accountUsername);
-        const productRes = await productList(accountUsername, 3);
-        const userInfoRes = await userInfo(accountUsername);
-
-        setUserData(userInfoRes);
-        setUserPosts(postRes);
-        setUserProducts(productRes);
+        if (!currentPage) {
+          const postRes = await userPost(accountUsername);
+          const userInfoRes = await userInfo(accountUsername);
+          setUserData(userInfoRes);
+          setUserPosts(postRes);
+        }
+        const productRes = await productList(accountUsername, 3, currentPage);
+        setUserProducts(preProduct => [...preProduct, ...productRes]);
         setIsLoading(false);
       };
       getUserInfo();
     } else {
       const getMyInfo = async () => {
-        const postRes = await userPost(localStorage.getItem("accountname"));
+        if (!currentPage) {
+          const postRes = await userPost(localStorage.getItem("accountname"));
+          const userInfoRes = await myInfo();
+          setUserData(userInfoRes);
+          setUserPosts(postRes);
+        }
         const productRes = await productList(
           localStorage.getItem("accountname"),
           3,
+          currentPage,
         );
-        const userInfoRes = await myInfo();
-        setUserData(userInfoRes);
-        setUserPosts(postRes);
-        setUserProducts(productRes);
+        setUserProducts(preProduct => [...preProduct, ...productRes]);
         setIsLoading(false);
       };
       getMyInfo();
     }
-  }, [accountUsername]);
+  }, [accountUsername, currentPage]);
 
   const handleModalClose = e => {
     setIsModal(false);
@@ -92,7 +97,11 @@ export default function Profile() {
               있는 내 프로필 페이지 입니다.
             </h1>
             <ProfileCard accountUsername={accountUsername} data={userData} />
-            <ProfileProduct data={userProducts} />
+            <ProfileProduct
+              data={userProducts}
+              setCurrentPage={setCurrentPage}
+              currentPage={currentPage}
+            />
             {userPosts?.post?.length >= 1 ? (
               <UserPostList
                 data={userPosts}


### PR DESCRIPTION
⚡ PR 한 줄 요약
프로필 컴포넌트에서 프로필 상품 컴포넌트 변경사함 머지 .
🔍 주요 변경 사항
상품 슬라이터 컴포넌트에서 상품을 3개씩 나눠서 api를 통해 불러오고 렌더링.
팔로우,언팔로우 버튼 여러번 클릭 방지
💬 참고 사항
변경 사항을 볼 수 있는 Screenshots, 레퍼런스 링크, 리뷰어들을 위한 코멘트 등을 작성해주세요.

💡 관련 이슈
Close #{이슈번호}
